### PR TITLE
fix: Bump default gas value for CHEQ

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -14,7 +14,7 @@ export const config = {
     COIN_TYPE: 118,
     COINGECKO_ID: 'cheqd-network',
     GAS_PRICE_STEP_LOW: 25,
-    GAS_PRICE_STEP_AVERAGE: 30,
-    GAS_PRICE_STEP_HIGH: 50,
+    GAS_PRICE_STEP_AVERAGE: 50,
+    GAS_PRICE_STEP_HIGH: 100,
     FEATURES: ['stargate', 'ibc-transfer', 'no-legacy-stdTx', 'ibc-go'],
 };

--- a/src/defaultGasValues.js
+++ b/src/defaultGasValues.js
@@ -1,7 +1,7 @@
 export const gas = {
     send: 80000,
     vote: 80000,
-    delegate: 160000,
+    delegate: 180000,
     un_delegate: 200000,
     re_delegate: 300000,
     claim_reward: 120000,


### PR DESCRIPTION
Currently, a lot of transactions are failing because the default gas needed for delegations seems to have gone slightly above 160k. This fix should resolve most issues people are seeing.